### PR TITLE
Add bogus width/height values for IE9

### DIFF
--- a/podcast-black.svg
+++ b/podcast-black.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" x="0" y="0" viewBox="-385 262.4 70.9 70.9" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" x="0" y="0" viewBox="-385 262.4 70.9 70.9" width="71" height="71" xml:space="preserve">
   <style type="text/css">
     .st0{fill:rgb(0,0,0);}
   </style>

--- a/podcast-white.svg
+++ b/podcast-white.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" x="0" y="0" viewBox="-385 262.4 70.9 70.9" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" x="0" y="0" viewBox="-385 262.4 70.9 70.9" width="71" height="71" xml:space="preserve">
   <style type="text/css">
     .st0{fill:rgb(255,255,255);}
   </style>


### PR DESCRIPTION
The SVGs need width/height values so that they work in IE9 (see http://stackoverflow.com/a/22970897/77199). I've just chosen the sizes that GitHub's preview rendering uses, rather than some 'correct', as it appears to make no difference.
